### PR TITLE
Add Sub-Genres

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,10 @@
 
 <body>
 	<div id='tooltip'></div>
+	<div id='popUpBox'>
+		<button id='closePopUp' onclick="closePopUp()">x</button>
+		<div id='popUpContent'></div>
+	</div>
 	<div class='column'>
 		<div id='clickContainer' class='row'>
 			<div id='instrumentContainer'>

--- a/index.html
+++ b/index.html
@@ -52,6 +52,18 @@
 				<div id='laptopProgressContainer' class='beatProgress'>
 					<progress id='laptopBeatProgress' value='0' max='1'></progress>
 				</div>
+				<div id='subgenreContainer'>
+					<button id="trance" class="subgenre" onClick="setLaptopGenre(this)" onmouseover='genreTooltip(this)' onmouseout='hideGenreTooltip()'>
+					<button id="house" class="subgenre" onClick="setLaptopGenre(this)" onmouseover='genreTooltip(this)' onmouseout='hideGenreTooltip()'>
+					<button id="drumAndBass" class="subgenre" onClick="setLaptopGenre(this)" onmouseover='genreTooltip(this)' onmouseout='hideGenreTooltip()'>
+					<button id="hardstyle" class="subgenre" onClick="setLaptopGenre(this)" onmouseover='genreTooltip(this)' onmouseout='hideGenreTooltip()'>
+					<button id="electro" class="subgenre" onClick="setLaptopGenre(this)" onmouseover='genreTooltip(this)' onmouseout='hideGenreTooltip()'>
+					<button id="industrial" class="subgenre" onClick="setLaptopGenre(this)" onmouseover='genreTooltip(this)' onmouseout='hideGenreTooltip()'>
+					<button id="dubstep" class="subgenre" onClick="setLaptopGenre(this)" onmouseover='genreTooltip(this)' onmouseout='hideGenreTooltip()'>
+				</div>
+				<div id = "dropProgressContainer">
+					<progress id='theDropProgress' value='0' max='500'></progress>
+				</div>
 			</div>
 			<div id='vocal' class='instrumentContent'>Under Construction!</div>
 			<div id='keyboard' class='instrumentContent'>

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -3,6 +3,7 @@ function Game() {
   this.tasks = [];
   this.laptopMultiplier = 1;
   this.activeLaptopSubgenre = "nogenre";
+  this.unlearnedLaptopSubgenres = ["trance", "house", "drumAndBass", "hardstyle", "electro", "industrial", "dubstep"];
   this.clicksPerBeat = 30;
   this.beatsPerSample = 25;
   this.samplesPerSong = 50;

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -2,6 +2,7 @@ function Game() {
   this.player = new Player();
   this.tasks = [];
   this.laptopMultiplier = 1;
+  this.activeLaptopSubgenre = "nogenre";
   this.clicksPerBeat = 30;
   this.beatsPerSample = 25;
   this.samplesPerSong = 50;
@@ -35,6 +36,7 @@ function addBeat(n) {
   game.player.beats += n;
   game.player.lifetimeBeats += n;
   game.player.addXp("laptop", (game.xpPerBeat * n));
+
   updateView();
 }
 

--- a/scripts/laptop.js
+++ b/scripts/laptop.js
@@ -1,5 +1,7 @@
 var beatInterval;
+var dropInterval;
 var markerReverse = false;
+var dropActive = false;
 var tempo = 15; // Starting tempo
 
 function startLaptop() {
@@ -48,6 +50,7 @@ function clickBeat() {
   /*
   	Advances the progress bar if the user has clicked the 'Make Beat' button.
   	Amount of progress is determined by how well the user lined up the marker with the different 'tiers' of zones.
+    The progress amount is then further altered by active sub-genre effects.
 
   	Green = multiplier amount (and adds to the multiplier)
   	Yellow = 1/2 multiplier amount (and removes from the multuplier)
@@ -55,6 +58,8 @@ function clickBeat() {
   */
 
   var progressAmount = 0;
+  var progressMultiplier = 1;
+  var maxMultiplier = 10;
   var progress = document.getElementById('laptopBeatProgress');
   var markerOffsets = getOffsets(document.querySelector('#marker'));
   var markerPoint = (markerOffsets.left + markerOffsets.right) / 2;
@@ -62,12 +67,38 @@ function clickBeat() {
   var leftYellowPoint = getOffsets(document.getElementById('leftYellowZone')).left;
   var rightYellowPoint = getOffsets(document.getElementById('rightYellowZone')).right;
 
+  switch(game.activeLaptopSubgenre) {
+    case "trance":
+      maxMultiplier -= 10;
+      break;
+    case "drumAndBass":
+      maxMultiplier += 20;
+      break;
+    case "house":
+      if (tempo == 25)
+        progressMultiplier *= 2;
+      break;
+    case "hardstyle":
+      if (tempo == 5)
+        progressMultiplier *=2;
+    case "dubstep":
+      if (dropActive == true)
+        progressMultiplier *= 10;
+    default:
+      break;
+  }
+
+  if (maxMultiplier < 1)
+    maxMultiplier = 1;
+
   // Determine how much to advance the progress bar
   if (greenOffsets.left <= markerPoint && markerPoint <= greenOffsets.right) {
     progressAmount = game.laptopMultiplier;
 
-    if (game.laptopMultiplier < 10)
+    if (game.laptopMultiplier < maxMultiplier)
       game.laptopMultiplier++;
+    else
+      game.laptopMultiplier = maxMultiplier;
   }
   else if (leftYellowPoint <= markerPoint && markerPoint <= rightYellowPoint) {
     progressAmount = Math.ceil(game.laptopMultiplier / 2);
@@ -76,10 +107,144 @@ function clickBeat() {
       game.laptopMultiplier--;
   }
   else {
+    if (game.activeLaptopSubgenre == "industrial")
+      progressMultiplier *= 5;
+
     progressAmount = 0.2;
     game.laptopMultiplier = 1;
   }
 
   updateMultiplier(game.laptopMultiplier, "laptopMultiplier");
-  updateProgress(progress, (progress.value + progressAmount), game.clicksPerBeat, addBeat);
+  updateProgress(progress, (progress.value + (progressAmount * progressMultiplier)), game.clicksPerBeat, addBeat);
+}
+
+/* Sub-genre functionality */
+
+function setLaptopGenre(obj) {
+  var progressContainer = document.getElementById("laptopBeatProgress");
+
+  // Revert sub-genre specific effects
+  if (game.activeLaptopSubgenre == "electro") {
+    var greenZone = document.getElementById("greenZone");
+    var leftYellowZone = document.getElementById("leftYellowZone");
+    var rightYellowZone = document.getElementById("rightYellowZone");
+
+    greenZone.style.width = "15%";
+    leftYellowZone.style.width = "18%";
+    rightYellowZone.style.width = "18%";
+  }
+  else if (game.activeLaptopSubgenre == "dubstep") {
+    document.getElementById("dropProgressContainer").style.visibility = "hidden";
+    clearInterval(dropInterval);
+    dropActive = false;
+    document.getElementById("laptop").style.boxShadow = "none";
+  }
+  else if (game.activeLaptopSubgenre == "drumAndBass") {
+    updateMultiplier(Math.min(game.laptopMultiplier, 10), "laptopMultiplier");
+  }
+
+  // Apply glow and sub-genre specific effects, change the active sub-genre
+  if (game.activeLaptopSubgenre == obj.id) {
+    obj.style.boxShadow = "none";
+    game.activeLaptopSubgenre = "nogenre";
+    progressContainer.style.boxShadow = "none"
+  }
+  else {
+    var glowColor = getComputedStyle(obj).borderColor;
+
+    if (game.activeLaptopSubgenre !== "nogenre") {
+      document.getElementById(game.activeLaptopSubgenre).style.boxShadow = "none";
+    }
+
+    progressContainer.style.boxShadow = "0px 0px 80px 1px " + glowColor;
+    obj.style.boxShadow = "0px 0px 5px 2px " + glowColor;
+
+    if (obj.id == "electro") {
+      var greenZone = document.getElementById("greenZone");
+      var leftYellowZone = document.getElementById("leftYellowZone");
+      var rightYellowZone = document.getElementById("rightYellowZone");
+
+      greenZone.style.width = "27%";
+      leftYellowZone.style.width = "12%";
+      rightYellowZone.style.width = "12%";
+    }
+    else if (obj.id == "dubstep") {
+      document.getElementById("dropProgressContainer").style.visibility = "visible";
+      dropInterval = setInterval(dropTick, 100);
+    }
+
+    game.activeLaptopSubgenre = obj.id;
+  }
+}
+
+function dropTick() {
+  if (dropActive == true) {
+    var dropProgress = document.getElementById("theDropProgress");
+    dropProgress.value = dropProgress.value - 5;
+
+    if (dropProgress.value <= 0) {
+      dropActive = false;
+      document.getElementById("laptop").style.boxShadow = "none";
+    }
+  }
+  else {
+    var dropProgress = document.getElementById("theDropProgress");
+    dropProgress.value = dropProgress.value + 1;
+
+    if (dropProgress.value >= dropProgress.max) {
+      var laptopContainer = document.getElementById("laptop");
+      var glowColor = getComputedStyle(document.getElementById("dubstep")).borderColor;
+
+      dropActive = true;
+      laptopContainer.style.boxShadow = "inset 0px 0px 150px 1px " + glowColor;
+    }
+  }
+}
+
+function genreTooltip(obj) {
+  var tooltip = document.getElementById('tooltip');
+  var offsets = getOffsets(obj);
+  var html = "<div id='tooltipHeader'>";
+
+  switch(obj.id) {
+    case "trance":
+      html += "Subgenre: Trance<br><br>Reduces the maximum combo by 10 (but not lower than 1). Generates 2x passive beat progress.";
+      break;
+    case "house":
+      html += "Subgenre: House<br><br>Clicking generates 2x beat progress when using the slowest tempo.";
+      break;
+    case "drumAndBass":
+      html += "Subgenre: Drum and Bass<br><br>Increases the maximum combo by 20.";
+      break;
+    case "hardstyle":
+      html += "Subgenre: Hardstyle<br><br>Clicking generates 2x beat progress when using the fastest tempo.";
+      break;
+    case "electro":
+      html += "Subgenre: Electro<br><br>Increases the size of the green zone and reduces the size of the yellow zones.";
+      break;
+    case "industrial":
+      html += "Subgenre: Industrial<br><br>Clicking in the red zones generates 5x more beat progress.";
+      break;
+    case "dubstep":
+      html += "Subgenre: Dubstep<br><br>Every 50 seconds, enter The Drop. When The Drop occurs, clicking generates 10x beat progress for 10 seconds.";
+      break;
+    default:
+      break;
+  }
+
+  html += "</div>";
+
+  tooltip.innerHTML = html;
+  tooltip.style.left = offsets.left - (obj.offsetWidth * 10);
+  tooltip.style.top = offsets.top + obj.offsetHeight + 5;
+  tooltip.style.width = "300px";
+  tooltip.style.display = "inline";
+
+  var tooltipHeader = document.getElementById('tooltipHeader');
+  tooltipHeader.style.borderBottom = "none";
+}
+
+function hideGenreTooltip() {
+  document.getElementById('tooltip').style.width = "200px";
+  hideTooltip();
 }

--- a/scripts/laptop.js
+++ b/scripts/laptop.js
@@ -201,36 +201,49 @@ function dropTick() {
   }
 }
 
-function genreTooltip(obj) {
-  var tooltip = document.getElementById('tooltip');
-  var offsets = getOffsets(obj);
-  var html = "<div id='tooltipHeader'>";
-
-  switch(obj.id) {
+function getTooltipInfo(subgenre) {
+  switch(subgenre) {
     case "trance":
-      html += "Subgenre: Trance<br><br>Reduces the maximum combo by 10 (but not lower than 1). Generates 2x passive beat progress.";
+      return {"genre": "Trance",
+              "tooltip": "Reduces the maximum combo by 10 (but not lower than 1). Generates 2x passive beat progress."};
       break;
     case "house":
-      html += "Subgenre: House<br><br>Clicking generates 2x beat progress when using the slowest tempo.";
+      return {"genre": "House",
+              "tooltip": "Clicking generates 2x beat progress when using the slowest tempo."};
       break;
     case "drumAndBass":
-      html += "Subgenre: Drum and Bass<br><br>Increases the maximum combo by 20.";
+      return {"genre": "Drum and Bass",
+              "tooltip": "Increases the maximum combo by 20."};
       break;
     case "hardstyle":
-      html += "Subgenre: Hardstyle<br><br>Clicking generates 2x beat progress when using the fastest tempo.";
+      return {"genre": "Hardstyle",
+              "tooltip": "Clicking generates 2x beat progress when using the fastest tempo."};
       break;
     case "electro":
-      html += "Subgenre: Electro<br><br>Increases the size of the green zone and reduces the size of the yellow zones.";
+      return {"genre": "Electro",
+              "tooltip": "Increases the size of the green zone and reduces the size of the yellow zones."};
       break;
     case "industrial":
-      html += "Subgenre: Industrial<br><br>Clicking in the red zones generates 5x more beat progress.";
+      return {"genre": "Industrial",
+              "tooltip": "Clicking in the red zones generates 5x more beat progress."};
       break;
     case "dubstep":
-      html += "Subgenre: Dubstep<br><br>Every 50 seconds, enter The Drop. When The Drop occurs, clicking generates 10x beat progress for 10 seconds.";
+      return {"genre": "Dubstep",
+              "tooltip": "Every 50 seconds, enter The Drop. When The Drop occurs, clicking generates 10x beat progress for 10 seconds."};
       break;
     default:
       break;
   }
+}
+
+function genreTooltip(obj) {
+  var tooltip = document.getElementById('tooltip');
+  var tooltipInfo = getTooltipInfo(obj.id);
+  var offsets = getOffsets(obj);
+  var html = "<div id='tooltipHeader'>";
+
+  if (tooltipInfo !== undefined)
+    html += "Subgenre: " + tooltipInfo.genre + "<br><br>" + tooltipInfo.tooltip;
 
   html += "</div>";
 
@@ -247,4 +260,37 @@ function genreTooltip(obj) {
 function hideGenreTooltip() {
   document.getElementById('tooltip').style.width = "200px";
   hideTooltip();
+}
+
+function populateGenrePopUp(taskName) {
+  var popUp = document.getElementById("popUpContent");
+
+  popUp.innerHTML += "<p id='popUpGenreHeader'>Select A Sub-Genre To Explore</p>";
+
+  game.unlearnedLaptopSubgenres.forEach(function (genre) {
+    var genreRow = "<div class='genreRow'>";
+    var tooltipInfo = getTooltipInfo(genre);
+
+    if (tooltipInfo !== undefined) {
+      genreRow += "<button class='popUpGenreButton' onclick='selectGenre(\"" + genre + "\")'>" + tooltipInfo.genre + "</button>";
+      genreRow += "<p class='popUpGenreText'>" + tooltipInfo.tooltip + "</p>";
+    }
+
+    genreRow += "</div>"
+    popUp.innerHTML += genreRow;
+  });
+}
+
+function selectGenre(subgenre) {
+  var task = getTask("Explore A Sub-Genre");
+  var htmlObj = document.getElementById(subgenre);
+  var index = game.unlearnedLaptopSubgenres.indexOf(subgenre);
+
+  htmlObj.style.display = "inline";
+  setLaptopGenre(htmlObj);
+  appendToOutputContainer("Your music is definitely leaning into the " + subgenre + " genre. Further exploring the genre will help you develop as a musician.");
+  task.finishFn(task);
+  game.unlearnedLaptopSubgenres.splice(index, 1);
+  closePopUp();
+  updateView();
 }

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -6,6 +6,7 @@ class Player {
     this.fame = 0;
     this.money = 0;
     this.lifetimeMoney = 0;
+    this.passiveBeatProgress = 0;
     this.beats = 0;
     this.lifetimeBeats = 0;
     this.samples = 0;

--- a/scripts/tasks.js
+++ b/scripts/tasks.js
@@ -324,7 +324,7 @@ function makeOnlinePortfolioTask() {
 
   var tooltip = {"description": "Build an online portfolio containing some of your custom samples. Unlocks opportunities to play your music at small gatherings.",
                  "cost": {"Samples": requiredSamples},
-                 "flavor": "You like your music, now you just have to get other people to like your music!"};
+                 "flavor": "Turns out the hardest part about becoming an artist is getting other people to like your music."};
 
   var onlinePortfolioTask = new Task("Make Online Portfolio", tooltip, checkFn, failFn, startFn);
   game.tasks.push(onlinePortfolioTask);
@@ -415,6 +415,31 @@ function makeDJAtNightclubTask() {
 
   var DJAtNightclubTask = new Task("DJ At Nightclub", tooltip, checkFn, undefined, startFn, undefined, finishFn, timeTaken);
   game.tasks.push(DJAtNightclubTask);
+}
+
+function makeBuyBeatBookTask() {
+  var requiredMoney = 10;
+
+  var checkFn = function() {
+    return game.player.money >= requiredMoney;
+  };
+
+  var failFn = function() {
+    appendToOutputContainer("You don't have enough money to purchase a notebook!");
+  };
+
+  var startFn = function(task) {
+    game.player.money -= requiredMoney;
+    game.player.passiveBeatProgress++;
+    removeTask(task.name);
+  };
+
+  var tooltip = {"description": "Purchase a notebook to write down ideas as they come to you. Permanently generates passive beat progress.",
+                 "cost": {"Money": requiredMoney},
+                 "flavor": "Some people like playing games. Others prefer when the game plays itself."};
+
+  var buyBeatBookTask = new Task("Book Of Beats", tooltip, checkFn, failFn, startFn);
+  game.tasks.push(buyBeatBookTask);
 }
 
 function makeBuyNewLaptopTask() {
@@ -526,7 +551,7 @@ function makeStudyOnlineTask() {
     stopActiveTask();
   };
 
-  var tooltip = {"description": "Do some online studying to improve your musical skills. Generates 1 beat every 5 seconds.",
+  var tooltip = {"description": "Do some online studying to improve your musical skills. Generates 1 beat every 5 seconds. Repeatable.",
                  "cost": {"Time": timeTaken},
                  "flavor": "You came here to procrastinate, but you ended up studying."};
 
@@ -573,7 +598,7 @@ function makeMusicClassTask() {
     stopActiveTask();
   };
 
-  var tooltip = {"description": "Take a music class to further develop your musical skills. Generates 1 beat every 2 seconds.",
+  var tooltip = {"description": "Take a music class to further develop your musical skills. Generates 1 beat every 2 seconds. Repeatable.",
                  "cost": {"Money": requiredMoney,
                           "Time": timeTaken},
                  "flavor": "$" + requiredMoney + " per class? Why does the world hate students?"};
@@ -641,4 +666,42 @@ function makeExperimentWithTempoTask() {
                  "flavor": "The ability to alter time itself, for the low cost of " + requiredBeats + " beats."};
   var tempoTask = new Task("Experiment With Tempo", tooltip, checkFn, failFn, startFn);
   game.tasks.push(tempoTask);
+}
+
+function makeExploreSubgenreTask() {
+  var requiredBeats = 100;
+
+  var checkFn = function() {
+    return game.player.beats >= requiredBeats;
+  }
+
+  var failFn = function() {
+    appendToOutputContainer("You don't have enough beats to unlock a sub-genre!");
+  }
+
+  var startFn = function(task) {
+    // TODO: Lightbox that allows user to pick the genre they want to explore
+    var subgenre = "house";
+    var htmlObj = document.getElementById(subgenre);
+    htmlObj.style.display = "inline";
+    setLaptopGenre(htmlObj);
+
+    // Remove after testing is done
+    document.getElementById("trance").style.display = "inline";
+    document.getElementById("industrial").style.display = "inline";
+    document.getElementById("hardstyle").style.display = "inline";
+    document.getElementById("dubstep").style.display = "inline";
+    document.getElementById("drumAndBass").style.display = "inline";
+    document.getElementById("electro").style.display = "inline";
+
+    game.player.beats -= requiredBeats;
+    appendToOutputContainer("Your music is definitely leaning into the " + subgenre + " genre. Further exploring the genre will help you develop as a musician.");
+    removeTask(task.name);
+  };
+
+  var tooltip = {"description": "Experiment with different sub-genres of electronic music. Unlocks a bonus effect of your choice for your laptop, improving beat production.",
+                 "cost": {"Beats": requiredBeats},
+                 "flavor": "You're not a real artist if people aren't arguing about what sub-sub-sub-genre your music is in."};
+  var subgenreTask = new Task("Explore A Sub-Genre", tooltip, checkFn, failFn, startFn);
+  game.tasks.push(subgenreTask);
 }

--- a/scripts/tasks.js
+++ b/scripts/tasks.js
@@ -668,9 +668,7 @@ function makeExperimentWithTempoTask() {
   game.tasks.push(tempoTask);
 }
 
-function makeExploreSubgenreTask() {
-  var requiredBeats = 100;
-
+function makeExploreSubgenreTask(requiredBeats) {
   var checkFn = function() {
     return game.player.beats >= requiredBeats;
   }
@@ -680,28 +678,17 @@ function makeExploreSubgenreTask() {
   }
 
   var startFn = function(task) {
-    // TODO: Lightbox that allows user to pick the genre they want to explore
-    var subgenre = "house";
-    var htmlObj = document.getElementById(subgenre);
-    htmlObj.style.display = "inline";
-    setLaptopGenre(htmlObj);
-
-    // Remove after testing is done
-    document.getElementById("trance").style.display = "inline";
-    document.getElementById("industrial").style.display = "inline";
-    document.getElementById("hardstyle").style.display = "inline";
-    document.getElementById("dubstep").style.display = "inline";
-    document.getElementById("drumAndBass").style.display = "inline";
-    document.getElementById("electro").style.display = "inline";
-
-    game.player.beats -= requiredBeats;
-    appendToOutputContainer("Your music is definitely leaning into the " + subgenre + " genre. Further exploring the genre will help you develop as a musician.");
-    removeTask(task.name);
+    openPopUp(populateGenrePopUp);
   };
+
+  var finishFn = function(task) {
+    game.player.beats -= requiredBeats;
+    removeTask(task.name);
+  }
 
   var tooltip = {"description": "Experiment with different sub-genres of electronic music. Unlocks a bonus effect of your choice for your laptop, improving beat production.",
                  "cost": {"Beats": requiredBeats},
                  "flavor": "You're not a real artist if people aren't arguing about what sub-sub-sub-genre your music is in."};
-  var subgenreTask = new Task("Explore A Sub-Genre", tooltip, checkFn, failFn, startFn);
+  var subgenreTask = new Task("Explore A Sub-Genre", tooltip, checkFn, failFn, startFn, undefined, finishFn);
   game.tasks.push(subgenreTask);
 }

--- a/scripts/triggers.js
+++ b/scripts/triggers.js
@@ -41,10 +41,45 @@ function oddJobsEventTrigger(natural) {
 /* Beat Progression */
 
 function firstBeatTrigger() {
-  if (game.player.beats >= 1) {
+  if (game.player.lifetimeBeats >= 1) {
     document.getElementById('beats').style.display = "block";
     appendToOutputContainer("You've created your first beat. A building block to something greater.");
+    triggerFnSet.add(tenthBeatTrigger);
+    return true;
+  }
+}
+
+function tenthBeatTrigger() {
+  if (game.player.lifetimeBeats >= 10) {
+    appendToOutputContainer("You have so many ideas! You should probably write some of them down.");
+    makeBuyBeatBookTask();
     triggerFnSet.add(firstSampleTrigger);
+    triggerFnSet.add(fiftiethBeatTrigger);
+    return true;
+  }
+}
+
+function fiftiethBeatTrigger() {
+  if (game.player.lifetimeBeats >= 50) {
+    appendToOutputContainer("You've got the basics down, maybe it's time to experiment with the tempo?");
+    makeExperimentWithTempoTask();
+    triggerFnSet.add(hundredthBeatTrigger);
+    return true;
+  }
+}
+
+function hundredthBeatTrigger() {
+  if (game.player.lifetimeBeats >= 100) {
+    appendToOutputContainer("As you make your hundredth beat, you can feel you're getting better at this.");
+    makeExploreSubgenreTask();
+    triggerFnSet.add(thousandthBeatTrigger);
+    return true;
+  }
+}
+
+function thousandthBeatTrigger() {
+  if (game.player.lifetimeBeats >= 1000) {
+    appendToOutputContainer("A thousand beats, made by your hand. Hard to beleive how far you've come.");
     return true;
   }
 }
@@ -53,8 +88,6 @@ function firstSampleTrigger() {
   if (game.player.beats >= game.beatsPerSample) {
     appendToOutputContainer("After creating a number of solid beats, you're ready to combine them into a short sample.");
     makeFirstSampleTask();
-    makeExperimentWithTempoTask();
-    triggerFnSet.add(hundredthBeatTrigger);
     triggerFnSet.add(firstSongTrigger);
     return true;
   }
@@ -64,21 +97,6 @@ function firstSongTrigger() {
   if (game.player.samples >= game.samplesPerSong) {
     appendToOutputContainer("With a handful of samples, you feel like you might have enough material to make a full song!");
     makeFirstSongTask();
-    return true;
-  }
-}
-
-function hundredthBeatTrigger() {
-  if (game.player.lifetimeBeats >= 100) {
-    appendToOutputContainer("As you make your hundredth beat, you can feel you're getting better at this.");
-    triggerFnSet.add(thousandthBeatTrigger);
-    return true;
-  }
-}
-
-function thousandthBeatTrigger() {
-  if (game.player.lifetimeBeats >= 1000) {
-    appendToOutputContainer("A thousand beats, made by your hand. Hard to beleive how far you've come.");
     return true;
   }
 }

--- a/scripts/triggers.js
+++ b/scripts/triggers.js
@@ -71,7 +71,15 @@ function fiftiethBeatTrigger() {
 function hundredthBeatTrigger() {
   if (game.player.lifetimeBeats >= 100) {
     appendToOutputContainer("As you make your hundredth beat, you can feel you're getting better at this.");
-    makeExploreSubgenreTask();
+    makeExploreSubgenreTask(100);
+    triggerFnSet.add(fiveHundredthBeatTrigger);
+    return true;
+  }
+}
+
+function fiveHundredthBeatTrigger() {
+  if (game.player.lifetimeBeats >= 500) {
+    makeExploreSubgenreTask(200);
     triggerFnSet.add(thousandthBeatTrigger);
     return true;
   }
@@ -79,6 +87,7 @@ function hundredthBeatTrigger() {
 
 function thousandthBeatTrigger() {
   if (game.player.lifetimeBeats >= 1000) {
+    makeExploreSubgenreTask(400);
     appendToOutputContainer("A thousand beats, made by your hand. Hard to beleive how far you've come.");
     return true;
   }

--- a/scripts/view.js
+++ b/scripts/view.js
@@ -7,9 +7,20 @@ function startTicking() {
 }
 
 function naturalTick() {
+  passiveResourceGeneration();
   updateActiveTask();
   adjustSongStats();
   updateView(true);
+}
+
+function passiveResourceGeneration() {
+  var progress = document.getElementById('laptopBeatProgress');
+  var progressAmount = game.player.passiveBeatProgress;
+
+  if (game.activeLaptopSubgenre == "trance")
+    progressAmount *= 2;
+
+  updateProgress(progress, (progress.value + progressAmount), game.clicksPerBeat, addBeat);
 }
 
 function updateView(natural) {
@@ -106,7 +117,7 @@ function fameTooltip() {
   var tooltip = document.getElementById('tooltip');
   var offsets = getOffsets(obj);
   var html = "<div id='tooltipHeader'>" +
-            "Fame is a measure of how well known you are as an artist.<br><br>" +
+             "Fame is a measure of how well known you are as an artist.<br><br>" +
              "You can increase your fame through various tasks or by releasing high quality songs and albums.<br><br>" +
              "The more famous you are, the larger your fanbase will be. Songs and Albums created by you will gain popularity faster if you have an established fanbase.<br><br>" +
              "Increased fame also leads to more lucrative opportunities such as playing at prestigious events with other famous artists or attending VIP social events." +
@@ -231,13 +242,14 @@ function updateProgress(progress, value, max, triggerFn) {
 }
 
 function updateMultiplier(multiplier, elementId) {
+  var colorAndFontShift = Math.min(10, multiplier);
   var multDiv = document.getElementById(elementId);
-  var r = 250 - (multiplier - 1) * 30;
-  var g = 250 - Math.abs(multiplier - 5) * 30;
-  var b = (multiplier - 5) * 50;
+  var r = 250 - (colorAndFontShift - 1) * 30;
+  var g = 250 - Math.abs(colorAndFontShift - 5) * 30;
+  var b = (colorAndFontShift - 5) * 50;
 
   multDiv.innerHTML = "x" + multiplier;
-  multDiv.style.fontSize = 15 + multiplier;
+  multDiv.style.fontSize = 15 + colorAndFontShift;
   multDiv.style.color = "rgb(" + r + "," + g + "," + b + ")";
 }
 

--- a/scripts/view.js
+++ b/scripts/view.js
@@ -305,3 +305,13 @@ function makeTaskButton(task) {
 
 	return html;
 }
+
+function openPopUp(populateFn) {
+  document.getElementById("popUpBox").style.display = "block";
+  populateFn();
+}
+
+function closePopUp() {
+  document.getElementById("popUpBox").style.display = "none";
+  document.getElementById("popUpContent").innerHTML = "";
+}

--- a/stylesheets/click-container.css
+++ b/stylesheets/click-container.css
@@ -232,8 +232,8 @@
 }
 
 #drumAndBass {
-  background-color: #2980B9;
-  border: 1px solid #5499C7;
+  background-color: #0064FA;
+  border: 1px solid #2177FA;
   display: none;
 }
 
@@ -283,6 +283,53 @@
 
 #dropProgressContainer > progress[value]::-webkit-progress-value {
   background-color: #8E44AD;
+}
+
+/* Sub-genre Pop-Up */
+#popUpButtons {
+  width: 100%;
+  text-align: center;
+}
+
+#popUpGenreHeader {
+  text-align: center;
+  margin-bottom: 15px;
+  margin-top: 15px;
+}
+
+.genreRow {
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.popUpGenreText {
+  font-size: 12px;
+  margin-left: 10px;
+  width: 75%;
+}
+
+.popUpGenreButton {
+  width: 120px;
+  height: 30px;
+  margin-top: 6px;
+  margin-right: 10px;
+  margin-left: 10px;
+  margin-bottom: 6px;
+  font-size: 12px;
+  border: 1px solid white;
+  color: white;
+  background-color: #222222;
+}
+
+.popUpGenreButton:hover {
+  cursor: pointer;
+  background-color: #333333;
+}
+
+.popUpGenreButton:focus {
+  outline: 0;
 }
 
 /*

--- a/stylesheets/click-container.css
+++ b/stylesheets/click-container.css
@@ -166,6 +166,7 @@
 
 #tempoSelector > input {
   margin: 9px 9px 9px 9px;
+  cursor: pointer;
 }
 
 #beatButtonContainer {
@@ -193,6 +194,95 @@
 #beatButtonContainer > button:hover {
   cursor: pointer;
   background-color: #333333;
+}
+
+/* Sub-genres */
+
+#subgenreContainer {
+  height: 8%;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 10px;
+}
+
+.subgenre {
+  margin-right: 5px;
+  border-radius: 15px;
+  width: 2%;
+  height: 50%;
+  cursor: pointer;
+}
+
+.subgenre:focus {
+  outline: 0;
+}
+
+#trance {
+  background-color: #5DADE2;
+  border: 1px solid #85C1E9;
+  display: none;
+}
+
+#house {
+  background-color: #E67E22;
+  border: 1px solid #EB984E;
+  display: none;
+}
+
+#drumAndBass {
+  background-color: #2980B9;
+  border: 1px solid #5499C7;
+  display: none;
+}
+
+#hardstyle {
+  background-color: #27AE60;
+  border: 1px solid #52BE80;
+  display: none;
+}
+
+#electro {
+  background-color: #F7DC6F;
+  border: 1px solid #F9E79F;
+  display: none;
+}
+
+#industrial {
+  background-color: #C0392B;
+  border: 1px solid #CD6155;
+  display: none;
+}
+
+#dubstep {
+  background-color: #8E44AD;
+  border: 1px solid #A569BD;
+  display: none;
+}
+
+#dropProgressContainer {
+  height: 4%;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  visibility: hidden;
+}
+
+#dropProgressContainer > progress[value] {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+#dropProgressContainer > progress[value]::-webkit-progress-bar {
+  background-color: #eee;
+  border-radius: 2px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.25) inset;
+}
+
+#dropProgressContainer > progress[value]::-webkit-progress-value {
+  background-color: #8E44AD;
 }
 
 /*

--- a/stylesheets/output-container.css
+++ b/stylesheets/output-container.css
@@ -6,4 +6,5 @@
 
 #outputContainer > p {
   margin-top: 3px;
+  font-size: 13px;
 }

--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -44,6 +44,8 @@ body {
   color: white;
 }
 
+/* Tooltip CSS */
+
 #tooltip {
   position: absolute;
   z-index: 100;
@@ -88,4 +90,36 @@ body {
   margin: 5px;
   padding-top: 5px;
   border-top: 1px solid white;
+}
+
+/* Pop Up CSS */
+
+#popUpBox {
+  display: none; /* Hidden by default */
+  position: fixed; /* Stay in place */
+  z-index: 10; /* Sit on top */
+  border: 2px solid white;
+  color: white;
+  background-color: var(--my-background-color);
+  left: 25%;
+  top: 15%;
+  width: 50%;
+  height: auto;
+}
+
+#closePopUp {
+  background-color: Transparent;
+  color: white;
+  font-size: 16px;
+  border: none;
+  overflow: hidden;
+  outline:none;
+  float: right;
+  margin-right: 5px;
+  margin-top: 5px;
+}
+
+#closePopUp:hover {
+  cursor: pointer;
+  color: red;
 }


### PR DESCRIPTION
- Adds 7 sub-genres with unique effects. You can currently get up to 3 of your choice.
- Adds Passive Beat Generation via the 'Book of Beats' task.
- Adds Pop-Up Box functionality that will be reusable for 'Make A Song' and other special tasks.
- Moved a few triggers around and added some new ones.
- Additional small changes

Known Issues:
- The 'Explore A Sub-Genre' task will be greyed out when you have an active task, despite not being an active task itself. Clicking on the greyed out task will still properly start the task. This is caused by an assumption that only active tasks will have finishFns (this is a special case)
- While the Pop-Up box is open, the user can still select things in the background. This makes it possible for the user to complete tasks while the Pop-Up box is open and end up with negative beats after choosing a sub-genre.
- When selecting the 'Drum and Bass' sub-genre, the output panel will use its internal name instead of it's proper name (ie. drumAndBass vs. Drum and Bass)
