### PR TITLE
Add Job and Study Tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,13 +58,13 @@
 					<progress id='laptopBeatProgress' value='0' max='1'></progress>
 				</div>
 				<div id='subgenreContainer'>
-					<button id="trance" class="subgenre" onClick="setLaptopGenre(this)" onmouseover='genreTooltip(this)' onmouseout='hideGenreTooltip()'>
-					<button id="house" class="subgenre" onClick="setLaptopGenre(this)" onmouseover='genreTooltip(this)' onmouseout='hideGenreTooltip()'>
-					<button id="drumAndBass" class="subgenre" onClick="setLaptopGenre(this)" onmouseover='genreTooltip(this)' onmouseout='hideGenreTooltip()'>
-					<button id="hardstyle" class="subgenre" onClick="setLaptopGenre(this)" onmouseover='genreTooltip(this)' onmouseout='hideGenreTooltip()'>
-					<button id="electro" class="subgenre" onClick="setLaptopGenre(this)" onmouseover='genreTooltip(this)' onmouseout='hideGenreTooltip()'>
-					<button id="industrial" class="subgenre" onClick="setLaptopGenre(this)" onmouseover='genreTooltip(this)' onmouseout='hideGenreTooltip()'>
-					<button id="dubstep" class="subgenre" onClick="setLaptopGenre(this)" onmouseover='genreTooltip(this)' onmouseout='hideGenreTooltip()'>
+					<button id="trance" class="subgenre" onClick="setLaptopGenre('trance')" onmouseover='genreTooltip(this)' onmouseout='hideGenreTooltip()'>
+					<button id="house" class="subgenre" onClick="setLaptopGenre('house')" onmouseover='genreTooltip(this)' onmouseout='hideGenreTooltip()'>
+					<button id="drumAndBass" class="subgenre" onClick="setLaptopGenre('drumAndBass')" onmouseover='genreTooltip(this)' onmouseout='hideGenreTooltip()'>
+					<button id="hardstyle" class="subgenre" onClick="setLaptopGenre('hardstyle')" onmouseover='genreTooltip(this)' onmouseout='hideGenreTooltip()'>
+					<button id="electro" class="subgenre" onClick="setLaptopGenre('electro')" onmouseover='genreTooltip(this)' onmouseout='hideGenreTooltip()'>
+					<button id="industrial" class="subgenre" onClick="setLaptopGenre('industrial')" onmouseover='genreTooltip(this)' onmouseout='hideGenreTooltip()'>
+					<button id="dubstep" class="subgenre" onClick="setLaptopGenre('dubstep')" onmouseover='genreTooltip(this)' onmouseout='hideGenreTooltip()'>
 				</div>
 				<div id = "dropProgressContainer">
 					<progress id='theDropProgress' value='0' max='500'></progress>
@@ -188,13 +188,50 @@
 			<p>You sit at your desk with nothing but ideas and an old laptop. This is where it all begins.</p>
 		</div>
 		<div id='taskContainer' class='row'>
-			<div id='tasks'>
-				<p>Tasks</p>
+			<div id='taskTabContainer'>
+				<button id="upgradeTab" class="taskActive" onclick="toggleTab('upgrade', 'task')">Tasks and Upgrades</button>
+				<button id="studyTab" class="task" onclick="toggleTab('study', 'task')">Studies</button>
+				<button id="jobTab" class="task" onclick="toggleTab('job', 'task')">Jobs</button>
 			</div>
-			<div id='taskProgressContainer'>
-				<p id='taskLabel'>Some Task</p>
-				<button onclick='cancelTask()'>x</button>
-				<progress id='taskProgress' value='0' , max='10'></progress>
+			<div id="upgradeContent" class="taskContent">
+				<div id="upgradeContainer">
+				</div>
+				<div id='taskProgressContainer'>
+					<p id='taskLabel'>Some Task</p>
+					<button onclick='cancelTask()'>x</button>
+					<progress id='taskProgress' value='0' , max='10'></progress>
+				</div>
+			</div>
+			<div id="studyContent" class="taskContent">
+				<div id="laptopStudyContainer" class="studyContainer">
+					<p>Laptop</p>
+					<p id="laptopStudyCost" class="wageRate"></p>
+					<p id="laptopStudyXp" class="xpModifier"></p>
+					<div id="laptopStudyTasks" class="taskHolder"></div>
+				</div>
+				<div id="keyboardStudyContainer" class="studyContainer">
+					<p>Keyboard</p>
+					<p id="keyboardStudyCost" class="wageRate"></p>
+					<p id="keyboardStudyXp" class="xpModifier"></p>
+					<div id="keyboardStudyTasks" class="taskHolder"></div>
+				</div>
+			</div>
+			<div id="jobContent" class="taskContent">
+				<div id="laptopJobContainer" class="studyContainer">
+					<p>DJ Contracts</p>
+					<p id="laptopJobFame" class="fameRate"></p>
+					<p id="laptopJobWage" class="wageRate"></p>
+					<p id="laptopJobProc" class="procRate"></p>
+					<div id="laptopJobTasks" class="taskHolder"></div>
+				</div>
+				<div id="keyboardJobContainer" class="studyContainer">
+					<p>Pianist Contracts</p>
+					<div id="keyboardJobTasks" class="taskHolder"></div>
+				</div>
+				<div id="oddJobContainer" class="studyContainer">
+					<p>Odd Jobs</p>
+					<div id="oddJobTasks" class="taskHolder"></div>
+				</div>
 			</div>
 		</div>
 		<div id='skillsContainer' class='row'>

--- a/index.html
+++ b/index.html
@@ -199,39 +199,48 @@
 				<div id='taskProgressContainer'>
 					<p id='taskLabel'>Some Task</p>
 					<button onclick='cancelTask()'>x</button>
-					<progress id='taskProgress' value='0' , max='10'></progress>
+					<progress id='taskProgress' class='taskProgress' value='0' , max='10'></progress>
 				</div>
 			</div>
 			<div id="studyContent" class="taskContent">
-				<div id="laptopStudyContainer" class="studyContainer">
-					<p>Laptop</p>
-					<p id="laptopStudyCost" class="wageRate"></p>
-					<p id="laptopStudyXp" class="xpModifier"></p>
-					<div id="laptopStudyTasks" class="taskHolder"></div>
+				<div id="studyContainer">
+					<div id="laptopStudyContainer" class="studyContainer">
+						<p>Laptop</p>
+						<p id="laptopStudyCost" class="wageRate"></p>
+						<p id="laptopStudyXp" class="xpModifier"></p>
+						<div id="laptopStudyTasks" class="taskHolder"></div>
+					</div>
+					<div id="keyboardStudyContainer" class="studyContainer">
+						<p>Keyboard</p>
+						<p id="keyboardStudyCost" class="wageRate"></p>
+						<p id="keyboardStudyXp" class="xpModifier"></p>
+						<div id="keyboardStudyTasks" class="taskHolder"></div>
+					</div>
 				</div>
-				<div id="keyboardStudyContainer" class="studyContainer">
-					<p>Keyboard</p>
-					<p id="keyboardStudyCost" class="wageRate"></p>
-					<p id="keyboardStudyXp" class="xpModifier"></p>
-					<div id="keyboardStudyTasks" class="taskHolder"></div>
-				</div>
+				<progress id="studyTaskProgress" class='taskProgress' value='5' , max='10'></progress>
 			</div>
 			<div id="jobContent" class="taskContent">
-				<div id="laptopJobContainer" class="studyContainer">
-					<p>DJ Contracts</p>
-					<p id="laptopJobFame" class="fameRate"></p>
-					<p id="laptopJobWage" class="wageRate"></p>
-					<p id="laptopJobProc" class="procRate"></p>
-					<div id="laptopJobTasks" class="taskHolder"></div>
+				<div id="jobContainer">
+					<div id="laptopJobContainer" class="studyContainer">
+						<p>DJ Contracts</p>
+						<p id="laptopJobFame" class="fameRate"></p>
+						<p id="laptopJobWage" class="wageRate"></p>
+						<p id="laptopJobProc" class="procRate"></p>
+						<div id="laptopJobTasks" class="taskHolder"></div>
+					</div>
+					<div id="keyboardJobContainer" class="studyContainer">
+						<p>Pianist Contracts</p>
+						<p id="keyboardJobFame" class="fameRate"></p>
+						<p id="keyboardJobWage" class="wageRate"></p>
+						<p id="keyboardJobProc" class="procRate"></p>
+						<div id="keyboardJobTasks" class="taskHolder"></div>
+					</div>
+					<div id="oddJobContainer" class="studyContainer">
+						<p>Odd Jobs</p>
+						<div id="oddJobTasks" class="taskHolder"></div>
+					</div>
 				</div>
-				<div id="keyboardJobContainer" class="studyContainer">
-					<p>Pianist Contracts</p>
-					<div id="keyboardJobTasks" class="taskHolder"></div>
-				</div>
-				<div id="oddJobContainer" class="studyContainer">
-					<p>Odd Jobs</p>
-					<div id="oddJobTasks" class="taskHolder"></div>
-				</div>
+				<progress id="jobTaskProgress" class='taskProgress' value='5' , max='10'></progress>
 			</div>
 		</div>
 		<div id='skillsContainer' class='row'>

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -72,3 +72,23 @@ function updateMultiplier(multiplier, elementId) {
   multDiv.style.fontSize = 15 + colorAndFontShift;
   multDiv.style.color = "rgb(" + r + "," + g + "," + b + ")";
 }
+
+function getJobChance(instrument, jobType) {
+  var jobAttributes = game.jobs[instrument][jobType];
+  var playerAttributes = game.player.jobs[instrument];
+  var occuranceRate = Math.round((jobAttributes.baseOccuranceRate - game.player.resources.fame.amount / 10) * playerAttributes.procMod);
+
+  return Math.max(occuranceRate, 1);
+}
+
+function getValidJobLocation(instrument, jobType, taskPrefix) {
+  if (taskPrefix == undefined)
+    taskPrefix = "";
+
+  var validLocations = game.jobs[instrument][jobType].locations.filter(function(job) {
+    if (getContext(taskPrefix + job) == undefined)
+      return job;
+  });
+
+  return validLocations[Math.floor(Math.random() * validLocations.length)];
+}

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -59,6 +59,53 @@ function Game() {
       maxMultiplier: 10
     }
   };
+  this.jobs = {
+    oddJobs: {
+      baseOccuranceRate: 60,
+      basePay: 10,
+      timeToComplete: 60,
+      locations: [
+        "Mow Lawns", "Shovel Snow", "Yardwork", "Change Tires",
+        "Walk Dogs", "Babysitting", "Rake Leaves", "Clean Windows"
+      ]
+    },
+    laptop: {
+      freelance: {
+        baseOccuranceRate: 250,
+        baseFame: 5,
+        variableFame: 5,
+        basePay: 50,
+        variablePay: 10,
+        baseXp: 50,
+        timeToComplete: 180,
+        locations: [
+          "Birthday Party", "House Party", "Corporate Event", "Wedding",
+          "Frat Party", "Fundraiser"
+        ]
+      },
+      nightclub: {
+        baseOccuranceRate: 500,
+        baseFame: 30,
+        variableFame: 15,
+        basePay: 250,
+        variablePay: 50,
+        baseXp: 250,
+        locations: [
+          "The Revision", "Rampage", "The Roxberry", "Nebula Nightclub",
+          "The Jungle", "Infinity", "Club Liquid", "Pulse", "Green Door"
+        ]
+      }
+    },
+    keyboard: {
+      freelance: {
+        baseFame: 5,
+        variableFame: 5,
+        basePay: 50,
+        variablePay: 10,
+        baseXp: 50
+      }
+    }
+  };
 };
 
 function newGame() {
@@ -98,6 +145,8 @@ function loadGame() {
   if (playerData !== null) {
     // Restore game state
     game = new Game();
+    // TODO: Before overwriting the default player object, merge in keys/values
+    // that are missing from the stored player object
     game.player = playerData;
 
     // Apply UI Changes

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -53,7 +53,11 @@ function Game() {
         slow: 15,
         fast: 10,
         fastest: 5
-      }
+      },
+      subgenres: [
+        "trance", "house", "drumAndBass", "hardstyle", "electro",
+        "industrial", "dubstep"
+      ]
     },
     keyboard: {
       maxMultiplier: 10
@@ -98,11 +102,14 @@ function Game() {
     },
     keyboard: {
       freelance: {
+        baseOccuranceRate: 250,
         baseFame: 5,
         variableFame: 5,
         basePay: 50,
         variablePay: 10,
-        baseXp: 50
+        baseXp: 50,
+        timeToComplete: 180,
+        locations: []
       }
     }
   };

--- a/scripts/laptop.js
+++ b/scripts/laptop.js
@@ -9,12 +9,18 @@ var markerReverse = false;
 
 function startLaptop() {
   var tempo = game.player.instruments.laptop.currentTempo;
+  var subgenre = game.player.instruments.laptop.subgenre;
   var progress = document.getElementById('laptopBeatProgress');
   var requiredProgress = Math.ceil(game.resources.beats.clicksPer * game.player.instruments.laptop.reqClicksMod);
 
   beatInterval = setInterval(animateBeat, game.instruments.laptop.tempoSpeeds[tempo]);
   updateMultiplier(game.player.instruments.laptop.multiplier, "laptopMultiplier");
   updateProgress(progress, game.player.instruments.laptop.currentProgress, requiredProgress, partial(addResource, "beats"));
+
+  if (subgenre !== undefined) {
+    setLaptopGenre(subgenre);
+    setLaptopGenre(subgenre); // Doing this twice clears and then reinitialized the subgenre
+  }
 
   if (game.player.instruments.laptop.subgenre == "dubstep")
     dropInterval = setInterval(dropTick, 100);
@@ -127,8 +133,10 @@ function clickBeat() {
 
 /* Sub-genre functionality */
 
-function setLaptopGenre(obj) {
+// TODO: Make this easier to call from the code
+function setLaptopGenre(subgenreId) {
   var activeSubgenre = game.player.instruments.laptop.subgenre;
+  var subgenreObj = document.getElementById(subgenreId);
   var progressContainer = document.getElementById("laptopBeatProgress");
 
   // Revert sub-genre specific effects
@@ -155,21 +163,21 @@ function setLaptopGenre(obj) {
   }
 
   // Apply glow and sub-genre specific effects, change the active sub-genre
-  if (activeSubgenre == obj.id) {
-    obj.style.boxShadow = "none";
+  if (activeSubgenre == subgenreId) {
+    subgenreObj.style.boxShadow = "none";
     progressContainer.style.boxShadow = "none"
     game.player.instruments.laptop.subgenre = undefined;
   } else {
-    var glowColor = getComputedStyle(obj).borderColor;
+    var glowColor = getComputedStyle(subgenreObj).borderColor;
 
     if (activeSubgenre !== undefined) {
       document.getElementById(activeSubgenre).style.boxShadow = "none";
     }
 
     progressContainer.style.boxShadow = "0px 0px 80px 1px " + glowColor;
-    obj.style.boxShadow = "0px 0px 5px 2px " + glowColor;
+    subgenreObj.style.boxShadow = "0px 0px 5px 2px " + glowColor;
 
-    if (obj.id == "electro") {
+    if (subgenreId == "electro") {
       var greenZone = document.getElementById("greenZone");
       var leftYellowZone = document.getElementById("leftYellowZone");
       var rightYellowZone = document.getElementById("rightYellowZone");
@@ -177,19 +185,19 @@ function setLaptopGenre(obj) {
       greenZone.style.width = "27%";
       leftYellowZone.style.width = "12%";
       rightYellowZone.style.width = "12%";
-    } else if (obj.id == "dubstep") {
+    } else if (subgenreId == "dubstep") {
       document.getElementById("dropProgressContainer").style.visibility = "visible";
       dropInterval = setInterval(dropTick, 100);
-    } else if (obj.id == "drumAndBass") {
+    } else if (subgenreId == "drumAndBass") {
       game.player.instruments.laptop.bonusMaxMultiplier += 20;
-    } else if (obj.id == "trance") {
+    } else if (subgenreId == "trance") {
       game.player.instruments.laptop.bonusMaxMultiplier -= 10;
       game.player.instruments.laptop.multiplier = Math.min(game.player.instruments.laptop.multiplier, game.instruments.laptop.maxMultiplier + game.player.instruments.laptop.bonusMaxMultiplier);
       game.player.instruments.laptop.passiveProgress++;
       updateMultiplier(game.player.instruments.laptop.multiplier, "laptopMultiplier");
     }
 
-    game.player.instruments.laptop.subgenre = obj.id;
+    game.player.instruments.laptop.subgenre = subgenreId;
   }
 }
 
@@ -280,7 +288,7 @@ function genreTooltip(obj) {
   tooltip.style.left = offsets.left - (obj.offsetWidth * 10);
   tooltip.style.top = offsets.top + obj.offsetHeight + 5;
   tooltip.style.width = "300px";
-  tooltip.style.display = "inline";
+  tooltip.style.visibility = "visible";
 
   var tooltipHeader = document.getElementById('tooltipHeader');
   tooltipHeader.style.borderBottom = "none";

--- a/scripts/laptop.js
+++ b/scripts/laptop.js
@@ -133,7 +133,6 @@ function clickBeat() {
 
 /* Sub-genre functionality */
 
-// TODO: Make this easier to call from the code
 function setLaptopGenre(subgenreId) {
   var activeSubgenre = game.player.instruments.laptop.subgenre;
   var subgenreObj = document.getElementById(subgenreId);
@@ -152,7 +151,7 @@ function setLaptopGenre(subgenreId) {
     document.getElementById("dropProgressContainer").style.visibility = "hidden";
     clearInterval(dropInterval);
     game.player.instruments.laptop.dropActive = false;
-    document.getElementById("laptop").style.boxShadow = "none";
+    document.getElementById("laptopContent").style.boxShadow = "none";
   } else if (activeSubgenre == "drumAndBass") {
     game.player.instruments.laptop.bonusMaxMultiplier -= 20;
     game.player.instruments.laptop.multiplier = Math.min(game.player.instruments.laptop.multiplier, game.instruments.laptop.maxMultiplier + game.player.instruments.laptop.bonusMaxMultiplier);
@@ -208,14 +207,14 @@ function dropTick() {
 
     if (dropProgress.value <= 0) {
       game.player.instruments.laptop.dropActive = false;
-      document.getElementById("laptop").style.boxShadow = "none";
+      document.getElementById("laptopContent").style.boxShadow = "none";
     }
   } else {
     var dropProgress = document.getElementById("theDropProgress");
     dropProgress.value = dropProgress.value + 1;
 
     if (dropProgress.value >= dropProgress.max) {
-      var laptopContainer = document.getElementById("laptop");
+      var laptopContainer = document.getElementById("laptopContent");
       var glowColor = getComputedStyle(document.getElementById("dubstep")).borderColor;
 
       game.player.instruments.laptop.dropActive = true;
@@ -301,10 +300,14 @@ function hideGenreTooltip() {
 
 function populateGenrePopUp(taskName) {
   var popUp = document.getElementById("popUpContent");
+  var unexploredSubgenres = game.instruments.laptop.subgenres.filter(function(genre) {
+    if (game.player.instruments.laptop.unlockedSubgenres.indexOf(genre) == -1)
+      return genre;
+  });
 
   popUp.innerHTML += "<p class='popUpHeader'>Select A Sub-Genre To Explore</p>";
 
-  game.player.instruments.laptop.unexploredSubgenres.forEach(function(genre) {
+  unexploredSubgenres.forEach(function(genre) {
     var genreRow = "<div class='popUpRow'>";
     var tooltipInfo = getTooltipInfo(genre);
 
@@ -322,13 +325,12 @@ function populateGenrePopUp(taskName) {
 function selectGenre(subgenre, taskName) {
   var task = getTask(taskName);
   var htmlObj = document.getElementById(subgenre);
-  var index = game.player.instruments.laptop.unexploredSubgenres.indexOf(subgenre);
 
   showUiElement(subgenre, "inline");
-  setLaptopGenre(htmlObj);
+  setLaptopGenre(subgenre);
   appendToOutputContainer("Your music is definitely leaning into the " + subgenre + " genre. Further exploring the genre will help you develop as a musician.");
   finishTask(task);
-  game.player.instruments.laptop.unexploredSubgenres.splice(index, 1);
+  game.player.instruments.laptop.unlockedSubgenres.push(subgenre);
   closePopUp();
   updateView();
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -18,8 +18,8 @@ var game;
 function init() {
   loadGame();
   startTicking();
-  addNewGameTask();
-  addCheatTask();
+  // addNewGameTask();
+  // addCheatTask();
   updateView();
 }
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -18,8 +18,8 @@ var game;
 function init() {
   loadGame();
   startTicking();
-  //addNewGameTask();
-  //addCheatTask();
+  addNewGameTask();
+  addCheatTask();
   updateView();
 }
 

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -50,8 +50,7 @@ function Player() {
       passiveProgress: 0,
       currentProgress: 0,
       subgenre: undefined,
-      // TODO: Move this into game object - add unlockedSubgenres to player object
-      unexploredSubgenres: ["trance", "house", "drumAndBass", "hardstyle", "electro", "industrial", "dubstep"],
+      unlockedSubgenres: [],
       dropActive: false
     },
     keyboard: {

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -50,6 +50,7 @@ function Player() {
       passiveProgress: 0,
       currentProgress: 0,
       subgenre: undefined,
+      // TODO: Move this into game object - add unlockedSubgenres to player object
       unexploredSubgenres: ["trance", "house", "drumAndBass", "hardstyle", "electro", "industrial", "dubstep"],
       dropActive: false
     },
@@ -61,17 +62,36 @@ function Player() {
       bonusMaxMultiplier: 0,
       passiveProgress: 0,
       currentProgress: 0
-    },
+    }
   };
   this.studies = {
     laptop: {
-      xpMod: 1.0
+      xpMod: 1.0,
+      costMod: 1.0
+    },
+    keyboard: {
+      xpMod: 1.0,
+      costMod: 1.0
     }
   };
   this.jobs = {
+    oddJobs: {
+      maxContracts: 5,
+      numContracts: 0
+    },
     laptop: {
+      jobType: undefined,
       procMod: 1.0,
-      moneyMod: 1.0
+      moneyMod: 1.0,
+      maxContracts: 3,
+      numContracts: 0
+    },
+    keyboard: {
+      jobType: undefined,
+      procMod: 1.0,
+      moneyMod: 1.0,
+      maxContracts: 3,
+      numContracts: 0
     }
   };
   this.skills = {

--- a/scripts/tasks.js
+++ b/scripts/tasks.js
@@ -159,14 +159,20 @@ function startActiveTask(task) {
   if (game.player.activeTask == undefined) {
     var context = getContextFromTask(task);
     var label = document.getElementById('taskLabel');
-    var progress = document.getElementById('taskProgress');
+    var progresses = document.getElementsByClassName("taskProgress");
 
     game.player.activeTask = context;
     label.innerHTML = task.name;
     game.player.activeTask.timeInProgress = 0;
-    progress.value = 0;
-    progress.max = task.timeToComplete;
     showUiElement("taskProgressContainer", "inline-block");
+
+    for (var i = 0; i < progresses.length; i++) {
+      var progress = progresses[i];
+
+      progress.value = 0;
+      progress.max = task.timeToComplete;
+      showUiElement(progress.id, "inline-block");
+    }
 
     return true;
   }
@@ -185,7 +191,7 @@ function updateActiveTask() {
     game.player.activeTask.timeInProgress++;
 
     var task = getTaskFromContext(game.player.activeTask);
-    var progress = document.getElementById('taskProgress');
+    var progresses = document.getElementsByClassName("taskProgress");
 
     if (task.tickFns !== undefined)
       task.tickFns.forEach(function(tickFn) {
@@ -195,7 +201,9 @@ function updateActiveTask() {
     if (game.player.activeTask.timeInProgress >= task.timeToComplete)
       task.finishFns.push(stopActiveTask);
 
-    updateProgress(progress, game.player.activeTask.timeInProgress, task.timeToComplete, partial(finishTask, task));
+    updateProgress(progresses[1], game.player.activeTask.timeInProgress, task.timeToComplete); // study tab progress
+    updateProgress(progresses[2], game.player.activeTask.timeInProgress, task.timeToComplete); // job tab progress
+    updateProgress(progresses[0], game.player.activeTask.timeInProgress, task.timeToComplete, partial(finishTask, task));
   }
 }
 
@@ -203,6 +211,8 @@ function stopActiveTask() {
   // Stop the currently active task
   game.player.activeTask = undefined;
   showUiElement("taskProgressContainer", "none");
+  showUiElement("studyTaskProgress", "none");
+  showUiElement("jobTaskProgress", "none");
 }
 
 function cancelTask() {
@@ -643,7 +653,7 @@ function advanceDJCareerTask(context) {
   switch (context.level) {
     case 1:
       requiredFame = 0;
-      requiredSamples = 5;
+      requiredSamples = 3;
       jobType = "freelance";
       description = "Become a Freelance DJ, unlocking opportunities to play at small gatherings.";
       flavor = "Turns out the hardest part about becoming an artist is getting other people to like your music.";
@@ -1160,4 +1170,8 @@ function increaseResourceXpTask(context) {
 
 function reduceXpRequiredTask(context) {
   // TODO: Reduces the amount of XP required to level a skill by a percentage
+}
+
+function moreContractsTask(context) {
+  // TODO: Increases the number of active contracts the player can have for a given instrument
 }

--- a/scripts/tasks.js
+++ b/scripts/tasks.js
@@ -596,19 +596,21 @@ function oddJobsTask(context) {
     earn money early on and is replaced with other opportunities as the player
     increases their skill levels.
   */
-  var timeToComplete = 60;
-  var moneyReward = 10;
+  var jobAttributes = game.jobs.oddJobs;
+  var updateContractsFn = function() {
+    game.player.jobs.oddJobs.numContracts--;
+  };
 
   var finishFns = [
-    partial(addResource, "money", moneyReward),
-    partial(appendToOutputContainer, "After an hour of labor, you take home a measly " + moneyReward + " bucks."),
-    partial(addTrigger, oddJobsEventTrigger)
+    partial(addResource, "money", jobAttributes.basePay),
+    partial(appendToOutputContainer, "After an hour of labor, you take home a measly " + jobAttributes.basePay + " bucks."),
+    updateContractsFn
   ];
 
   var tooltip = {
     "description": "Rewards $10.",
     "cost": {
-      "Time": timeToComplete
+      "Time": jobAttributes.timeToComplete
     },
     "flavor": "Even the most famous of legends have humble beginnings."
   };
@@ -616,7 +618,7 @@ function oddJobsTask(context) {
   return {
     name: context.taskName,
     finishFns: finishFns,
-    timeToComplete: timeToComplete,
+    timeToComplete: jobAttributes.timeToComplete,
     tooltip: tooltip
   };
 }
@@ -633,30 +635,36 @@ function advanceDJCareerTask(context) {
 
   var requiredFame;
   var requiredSamples;
-  var outputText;
+  var jobType;
   var description;
   var flavor;
-  var eventTrigger;
+  var outputText;
 
   switch (context.level) {
     case 1:
       requiredFame = 0;
       requiredSamples = 5;
-      outputText = "You've completed your online portfolio. Soon, your first clients will reach out to you!";
+      jobType = "freelance";
       description = "Become a Freelance DJ, unlocking opportunities to play at small gatherings.";
       flavor = "Turns out the hardest part about becoming an artist is getting other people to like your music.";
-      eventTrigger = freelanceDJEventTrigger;
+      outputText = "You've completed your online portfolio. Soon, your first clients will reach out to you!";
       break;
     case 2:
       requiredFame = 50;
       requiredSamples = 30;
-      outputText = "Many of the nightclub owners liked the samples you showed them!";
+      jobType = "nightclub";
       description = "Unlocks more lucrative opportunities to DJ at nightclubs. Requires 50 Fame.";
       flavor = "Nightclubs during the day are... strange.";
-      eventTrigger = nightclubDJEventTrigger;
+      outputText = "Many of the nightclub owners liked the samples you showed them!";
       break;
     default:
       return null;
+  };
+
+  var updateJobTypeFn = function() {
+    game.player.jobs.laptop.jobType = jobType;
+    if (context.level == 1)
+      addTrigger(DJEventTrigger);
   };
 
   var checkFns = [
@@ -665,9 +673,11 @@ function advanceDJCareerTask(context) {
   ];
 
   var startFns = [
+    partial(showUiElement, "jobTab", "inline"),
+    partial(showUiElement, "laptopJobContainer", "block"),
     partial(removeResource, "samples", requiredSamples),
-    partial(addTrigger, eventTrigger),
-    partial(appendToOutputContainer, outputText)
+    partial(appendToOutputContainer, outputText),
+    updateJobTypeFn
   ];
 
   var tooltip = {
@@ -686,59 +696,56 @@ function advanceDJCareerTask(context) {
   };
 }
 
-function workAsDJTask(context) {
+function workJobTask(context) {
   /*
-    This task becomes available when a DJ Event is triggered. There are various
-    levels of DJ work available. Rewards Laptop XP, Money, and Fame and requires
-    timeToComplete depending on the context.
+    This task becomes available when a Job Event is triggered. There are various
+    types of work available for all instruments (ie. Freelance work).
 
-    On completion, reinsert the given level of event trigger to the triggers list.
+    Completion of the task rewards Fame, Money and XP for the given instrument,
+    where amounts are determined by the type of work.
   */
-  var xpReward;
-  var moneyReward;
-  var fameReward;
-  var timeToComplete;
+  var taskAttributes = game.jobs[context.instrument][context.jobType];
+  var playerAttributes = game.player.jobs[context.instrument];
+  var moneyReward = Math.round((taskAttributes.basePay + context.bonusMoney) * playerAttributes.moneyMod);
+  var fameReward = taskAttributes.baseFame + context.bonusFame;
   var outputText;
   var flavor;
-  var eventTrigger;
 
-  switch (context.level) {
-    case 1:
-      xpReward = 50;
-      moneyReward = 50;
-      fameReward = 5;
-      timeToComplete = 180;
-      outputText = "After a few hours work at a " + context.djEvent.toLowerCase() + ", you manage to make $50!";
-      flavor = "Turns out, parties are a lot less fun when you're working.";
-      eventTrigger = freelanceDJEventTrigger;
+  var updateContractsFn = function() {
+    game.player.jobs[context.instrument].numContracts--;
+  };
+
+  switch (context.instrument) {
+    case "laptop":
+      switch (context.jobType) {
+        case "freelance":
+          outputText = "After a few hours work at a " + context.location + ", you manage to make $" + moneyReward + "!";
+          flavor = "Turns out, parties are a lot less fun when you're working.";
+          break;
+        case "nightclub":
+          outputText = "After a crazy night at " + context.location + ", you manage to make a solid $" + moneyReward + "!";
+          flavor = "Thiss isss myyy sooooooooong!";
+          break;
+      };
       break;
-    case 2:
-      xpReward = 250;
-      moneyReward = 250;
-      fameReward = 30;
-      timeToComplete = 180;
-      outputText = "After a crazy night at a club, you manage to make a solid $250!";
-      flavor = "'This isss myyy sooooooooong!' - That White Girl";
-      eventTrigger = nightclubDJEventTrigger;
-      break;
+    case "keyboard":
+      return null; // for now
     default:
       return null;
   };
 
-  moneyReward = Math.round(moneyReward * game.player.jobs.laptop.moneyMod);
-
   var finishFns = [
-    partial(addXp, "laptop", xpReward),
+    partial(addXp, context.instrument, taskAttributes.baseXp),
     partial(addResource, "money", moneyReward),
     partial(addResource, "fame", fameReward),
     partial(appendToOutputContainer, outputText),
-    partial(addTrigger, eventTrigger)
+    updateContractsFn
   ];
 
   var tooltip = {
-    "description": "Rewards " + fameReward + " Fame, $" + moneyReward + " and " + xpReward + " Laptop XP.",
+    "description": "Rewards " + fameReward + " Fame, $" + moneyReward + " and " + taskAttributes.baseXp + " " + context.instrument + " XP.",
     "cost": {
-      "Time": timeToComplete
+      "Time": taskAttributes.timeToComplete
     },
     "flavor": flavor
   };
@@ -747,7 +754,7 @@ function workAsDJTask(context) {
     name: context.taskName,
     finishFns: finishFns,
     tooltip: tooltip,
-    timeToComplete: timeToComplete
+    timeToComplete: taskAttributes.timeToComplete
   };
 }
 

--- a/scripts/triggers.js
+++ b/scripts/triggers.js
@@ -81,7 +81,7 @@ function tenthBeatTrigger() {
 }
 
 function fiftiethBeatTrigger() {
-  // TODO: What does this do now?
+  // TODO: What does this do now? Achievement?
   if (game.player.stats.beats.lifetime >= 50) {
     addTrigger(hundredthBeatTrigger);
     return true;
@@ -89,8 +89,7 @@ function fiftiethBeatTrigger() {
 }
 
 function hundredthBeatTrigger() {
-  // TODO: What does this do now?
-  // Achievement?
+  // TODO: What does this do now? Achievement?
   if (game.player.stats.beats.lifetime >= 100) {
     addTrigger(fiveHundredthBeatTrigger);
     return true;
@@ -98,8 +97,7 @@ function hundredthBeatTrigger() {
 }
 
 function fiveHundredthBeatTrigger() {
-  // TODO: What does this do now?
-  // Achievement?
+  // TODO: What does this do now? Achievement?
   if (game.player.stats.beats.lifetime >= 500) {
     addTrigger(thousandthBeatTrigger);
     return true;
@@ -107,7 +105,7 @@ function fiveHundredthBeatTrigger() {
 }
 
 function thousandthBeatTrigger() {
-  // Achievement?
+  // TODO: What does this do now? Achievement?
   if (game.player.stats.beats.lifetime >= 1000) {
     appendToOutputContainer("A thousand beats, made by your hand. Hard to beleive how far you've come.");
     return true;
@@ -220,6 +218,7 @@ function levelTwoLaptopTrigger() {
     appendToOutputContainer("If you want to get better at this, you're going to have to practice.");
     showUiElement("studyTab", "inline");
     showUiElement("laptopStudyContainer", "block");
+    tabNotifyAnimation("studyTab", "taskActive");
     addTask(context);
     addTrigger(levelThreeLaptopTrigger);
     return true;
@@ -371,7 +370,7 @@ function levelElevenLaptopTrigger() {
 
 function levelTwelveLaptopTrigger() {
   // Unlocks Level 2 DJ Study Task
-  // TODO: Make a task which gives you level 2 studying?
+  // TODO: Make a task which gives you level 2 studying? Make level 2 studying cost money?
   if (game.player.skills.laptop.level >= 12) {
     var context = {
       taskId: "genericStudyTask",
@@ -383,6 +382,7 @@ function levelTwelveLaptopTrigger() {
     };
 
     appendToOutputContainer("Furthering your DJ skills will require some research!");
+    tabNotifyAnimation("studyTab", "taskActive");
     addTask(context);
     addTrigger(levelThirteenLaptopTrigger);
     return true;
@@ -407,7 +407,6 @@ function levelThirteenLaptopTrigger() {
 
 function levelFourteenLaptopTrigger() {
   // Level 2 DJ Job
-  // TODO: Make Fame requirement part of task
   if (game.player.skills.laptop.level >= 14) {
     var context = {
       taskId: "advanceDJCareerTask",
@@ -481,21 +480,6 @@ function unlockNightclubTrigger() {
   ---- Event Triggers -----
 */
 
-// TODO: Make these common functions (ie. getJobChance, getValidJobTypes)
-function getJobData(jobAttributes, playerAttributes) {
-  var validJobs = jobAttributes.jobTypes.filter(function(job) {
-    if (getContext("DJ At " + job) == undefined)
-      return job;
-  });
-
-  return {
-    avgTicks: (jobAttributes.baseOccuranceRate - game.player.resources.fame.amount) * playerAttributes.procMod,
-    jobType: validJobs[Math.floor(Math.random() * validJobs)],
-    bonusMoney: Math.round(Math.random() * jobAttributes.variablePay),
-    bonusFame: Math.round(Math.random() * jobAttributes.variableFame),
-  };
-}
-
 function oddJobsEventTrigger(natural) {
   /*
     Event Trigger for Odd Job tasks. Odd Job tasks are Job Tasks which are
@@ -517,7 +501,6 @@ function oddJobsEventTrigger(natural) {
     if (Math.random() < 1 / avgTicks) {
       showUiElement("jobTab", "inline");
       showUiElement("oddJobContainer", "block");
-      // TODO: jobTab animation
 
       var validJobs = game.jobs.oddJobs.locations.filter(function(job) {
         if (getContext(job) == undefined)
@@ -533,6 +516,7 @@ function oddJobsEventTrigger(natural) {
       };
 
       appendToOutputContainer("A neighbor comes by with an opportunity to make a little cash.");
+      tabNotifyAnimation("jobTab", "taskActive");
       game.player.jobs.oddJobs.numContracts++;
       addTask(context);
       addTrigger(oddJobsEventTrigger);
@@ -580,6 +564,7 @@ function DJEventTrigger(natural) {
         };
 
         appendToOutputContainer("A client has contacted you with an opportunity to DJ for a " + location.toLowerCase() + "!");
+        tabNotifyAnimation("jobTab", "taskActive");
         game.player.jobs.laptop.numContracts++;
         addTask(context);
         addTrigger(DJEventTrigger);

--- a/scripts/view.js
+++ b/scripts/view.js
@@ -107,7 +107,7 @@ function updateTaskContent(contentId, contexts, taskType, instrument) {
   var html = "";
   var filteredContexts = contexts.filter(function(context) {
     if (taskType == undefined && context.taskType == taskType && context.taskName != "Make New Song")
-        return context;
+      return context;
     else if (context.taskType == taskType && context.instrument == instrument)
       return context;
   });
@@ -123,7 +123,7 @@ function updateTaskContent(contentId, contexts, taskType, instrument) {
 
   if (taskType == "study")
     updateStudyStats(instrument);
-  else if (taskType == "job" && instrument != "none")
+  else if (taskType == "job" && instrument !== "none")
     updateJobStats(instrument);
 }
 
@@ -292,6 +292,15 @@ function toggleTab(tabId, groupId) {
     stopLaptop();
     stopKeyboard();
     startInstrument(tabId);
+  }
+}
+
+function tabNotifyAnimation(tabId, activeTabClass) {
+  if (document.getElementsByClassName(activeTabClass)[0].id !== tabId) {
+    var tab = document.getElementById(tabId);
+    tab.classList.remove("backgroundColorNotify");
+    void tab.offsetWidth; // css magic to allow replay of the error animation
+    tab.classList.add("backgroundColorNotify");
   }
 }
 

--- a/scripts/view.js
+++ b/scripts/view.js
@@ -299,7 +299,7 @@ function tabNotifyAnimation(tabId, activeTabClass) {
   if (document.getElementsByClassName(activeTabClass)[0].id !== tabId) {
     var tab = document.getElementById(tabId);
     tab.classList.remove("backgroundColorNotify");
-    void tab.offsetWidth; // css magic to allow replay of the error animation
+    void tab.offsetWidth; // css magic to allow replay of the animation
     tab.classList.add("backgroundColorNotify");
   }
 }

--- a/stylesheets/items-container.css
+++ b/stylesheets/items-container.css
@@ -42,7 +42,7 @@
 }
 
 /* Hide non-active tab content by default */
-#songs, #albums {
+#songsContent, #albumsContent {
   display: none;
 }
 
@@ -206,7 +206,9 @@
   margin-bottom: 6px;
 }
 
-/* Song PopUp */
+/*
+  ------ CSS For Songs Pop Up ------
+*/
 
 #songNameInput {
   margin-left: 5px;
@@ -218,19 +220,6 @@
   line-height: 15px;
   text-align: center;
 }
-
-/*
-#songDetails {
-  margin-top: 10px;
-  margin-bottom: 10px;
-  margin-left: 5%;
-  font-size: 12px;
-}
-
-li {
-  margin-top: 10px;
-}
-*/
 
 .resourceLabel {
   width: 15%;

--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -198,6 +198,18 @@ button:focus, input:focus {
   border-radius: 50%;
 }
 
+/* Notification Animation */
+.backgroundColorNotify {
+  animation-name: backgroundColorNotify;
+  animation-duration: 1s;
+}
+
+@keyframes backgroundColorNotify {
+  0% { background-color: #444444;}
+  50% { background-color: orange;}
+  100% { background-color: #444444;}
+}
+
 /* Error Animation */
 .backgroundColorError {
   animation-name: backgroundColorError;

--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -42,11 +42,17 @@ button:focus, input:focus {
   height: 50%;
 }
 
-#outputContainer, #taskContainer, #skillsContainer {
+#outputContainer, #skillsContainer {
   float: right;
   height: 33.33333%;
   padding-left: 6px;
   padding-top: 6px;
+  color: white;
+}
+
+#taskContainer {
+  float: right;
+  height: 33.33333%;
   color: white;
 }
 
@@ -55,7 +61,7 @@ button:focus, input:focus {
 #tooltip {
   position: absolute;
   z-index: 100;
-  display: none;
+  visibility: hidden;
   overflow: hidden;
   background: #111111;
   opacity: 0.95;

--- a/stylesheets/task-container.css
+++ b/stylesheets/task-container.css
@@ -1,16 +1,6 @@
-#tasks {
-  width: 100%;
-  height: 80%;
-}
-
-#tasks > button {
-  width: 120px;
-  height: 30px;
-  margin-top: 6px;
-  margin-right: 20px;
-  margin-bottom: 6px;
-  font-size: 12px;
-}
+/*
+  ------ General CSS For Tasks ------
+*/
 
 .validTask {
   border: 1px solid white;
@@ -29,10 +19,15 @@
   background-color: #333333;
 }
 
+/*
+  ------ CSS For Task Progress Container ------
+*/
+
 #taskProgressContainer {
   width: 100%;
   height: 20%;
   display: none;
+  margin-left: 6px;
 }
 
 #taskProgressContainer > p {
@@ -70,4 +65,142 @@
 
 #taskProgressContainer > progress[value]::-webkit-progress-value {
   background-color: #33cc33;
+}
+
+/*
+  ------ CSS For Task Tabs ------
+*/
+
+#taskTabContainer {
+  width: 100%;
+  overflow: hidden;
+  background-color: #222222;
+}
+
+#upgradeTab, #studyTab, #jobTab {
+  color: white;
+  float: left;
+  border: none;
+  cursor: pointer;
+  padding: 8px 10px;
+  font-size: 12px;
+  width: 33.3333333%;
+}
+
+.taskActive {
+  background-color: var(--my-background-color);
+}
+
+.task {
+  background-color: #444444
+}
+
+.task:hover {
+  background-color: #555555;
+}
+
+.taskContent {
+  padding-left: 6px;
+  display: block;
+  height: 100%;
+}
+
+/* Hide song and album tabs by default */
+#studyTab, #jobTab {
+  display: none;
+}
+
+/* Hide non-active tab content by default */
+#studyContent, #jobContent {
+  display: none;
+  height: calc(100% - 28px); /* Minus the height of the tabs */
+  overflow: auto;
+  overflow-x: hidden;
+}
+
+/*
+  ------ CSS For Task Tab Content ------
+*/
+
+#upgradeContent {
+  padding-top: 6px;
+  margin-right: 10px;
+}
+
+#upgradeContainer {
+  height: 70%;
+}
+
+#upgradeContainer > button {
+  width: 120px;
+  height: 30px;
+  margin-top: 6px;
+  margin-bottom: 6px;
+  margin-right: 10px;
+  margin-left: 10px;
+  font-size: 12px;
+}
+
+#laptopJobTasks, #keyboardJobTasks {
+  width: 60%;
+}
+
+.taskHolder {
+  border-top: 1px;
+  border-bottom: 1px;
+  border-style: none solid;
+  height: 45px;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+.taskHolder > button {
+  width: 120px;
+  height: 30px;
+  margin-top: 6px;
+  margin-bottom: 6px;
+  margin-right: 10px;
+  margin-left: 10px;
+  font-size: 12px;
+  white-space: normal;
+}
+
+.studyContainer {
+  padding-top: 6px;
+  margin-right: 6px;
+  width: 100%;
+  display: none;
+}
+
+.studyContainer > p {
+  padding-top: 6px;
+  margin-bottom: 6px;
+}
+
+.fameRate {
+  color: #ff751a;
+  font-size: 12px;
+  margin-right: 6px;
+  display: inline;
+}
+
+.wageRate {
+  color: #00bb00;
+  font-size: 12px;
+  margin-right: 6px;
+  display: inline;
+}
+
+.procRate {
+  color: #F7DC6F;
+  font-size: 12px;
+  margin-right: 6px;
+  display: inline;
+}
+
+.xpModifier {
+  color: #3399ff;
+  font-size: 12px;
+  margin-right: 6px;
+  display: inline;
 }

--- a/stylesheets/task-container.css
+++ b/stylesheets/task-container.css
@@ -50,20 +50,26 @@
   color: red;
 }
 
-#taskProgressContainer > progress[value] {
-  width: 99%;
+#taskProgress[value] {
   height: 30%;
-  -webkit-appearance: none;
-  appearance: none;
 }
 
-#taskProgressContainer > progress[value]::-webkit-progress-bar {
+.taskProgress[value] {
+  width: 99%;
+  height: 5px;
+  -webkit-appearance: none;
+  appearance: none;
+  display: none;
+  margin-top: 2px;
+}
+
+.taskProgress[value]::-webkit-progress-bar {
   background-color: #eee;
   border-radius: 2px;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.25) inset;
 }
 
-#taskProgressContainer > progress[value]::-webkit-progress-value {
+.taskProgress[value]::-webkit-progress-value {
   background-color: #33cc33;
 }
 
@@ -113,7 +119,10 @@
 /* Hide non-active tab content by default */
 #studyContent, #jobContent {
   display: none;
-  height: calc(100% - 28px); /* Minus the height of the tabs */
+}
+
+#studyContainer, #jobContainer {
+  height: calc(100% - 38px); /* Minus the height of the tabs and progress bar */
   overflow: auto;
   overflow-x: hidden;
 }


### PR DESCRIPTION
- Reworked tabs to make them more generic and easier to implement
- Added tabs to the Tasks pane (Tasks and Upgrades, Studies, Jobs)
   - Study tasks now only show up in the Studies tab and are organized by instrument.
   - Job tasks now only show up in the Jobs tab and are organized by instrument. 
   - The player can now hold up to 3 job 'contracts' at a time (per instrument). In the future, this will be upgradable to 5.
   - Added a mini progress bar to the study/job tabs so the player can still see active task progress without it taking up so much space (since those tabs are busier)
   - Added stats to the Study/Job tabs so things like, job proc chance, expected income, and expected fame are more transparent.
   - Added an animation to the tabs that notifies the user when a new task is available while those tabs are not active.
- Reworked the "workAsDJTask" task to be generic for all levels of work for all instruments. Job-specific information (ie. constants such as base pay, xp, fame) have been moved to the Game object.
   - Added some variance to job contract rewards to make them a little more interesting
   - Added a list of possible Nightclub locations to the level 2 DJ Job. This is to support the new model of a player having multiple open contracts at a time.
- Combined the DJ Event triggers to make a single generic trigger. The level/type of work done is stored in the player object, and will be toggle-able in the future via a dropdown.
- Reworked the setLaptopGenre function to take in the subgenre ID instead of the HTML Object. This makes it easier to call this function from the code.
- Fixed an issue with subgenres not reapplying after a page refresh.
- Fixed a bug with the glow effect for "The Drop" (dubstep subgenre effect)
- Replaced the "unexploredSubgenres" list in the player object with a "unlockedSubgenres" list. Added a full list of available subgenres to the Game object. The list of unlearned subgenres is calculated by comparing the full list of subgenres to the list of already unlocked ones.
   - This change makes it easier to add new subgenres in the future.
- "Create Online Portfolio" task now requires 3 samples to complete, down from 5
- Added a deleteTrigger function
- Made an improvement to the tooltip functionality to prevent the tooltip from overlapping with the right side of the screen